### PR TITLE
Fix bug with request signature code

### DIFF
--- a/lib/WixConnect.js
+++ b/lib/WixConnect.js
@@ -155,7 +155,7 @@ WixAPIRequest.prototype = {
             if(a.param > b.param) return 1;
             return 0;
         });
-        var out = this.verb + "\n" + urlLib.parse(this.path).pathname + "\n" + _.pluck(parameters, 'value').join('\n');
+        var out = this.verb + "\n" + urlLib.parse(this.path + this.paths.toString()).pathname + "\n" + _.pluck(parameters, 'value').join('\n');
         if(this.postData) {
             out += "\n" + this.postData;
         }


### PR DESCRIPTION
The request signature code did not sign the entire request path. This affected calls like `wixAPI.Contacts.getContactById`, causing them to fail with an error message (`"Signature verification failure"`, error code -23004)
