### PR TITLE
propose changes to keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ var express = require('express');
 var app = express();
 var wix = require('openapi-node');
 
-var APP_SECRET = 'YOUR_APP_SECRET';
-var APP_ID = 'YOUR_APP_ID';
+var APP_ID = 'YOUR_APP_KEY';
+var APP_SECRET = 'YOUR_APP_SECRET_KEY';
 
 // The route should match the app endpoint set during registration
 app.get('/', function (req, res) {


### PR DESCRIPTION
first provide the app key, then the secret key. This is more consistent with the way the keys are presented on the site.
