### PR TITLE
Fix http response handling

### DIFF
--- a/lib/WixClient.js
+++ b/lib/WixClient.js
@@ -898,7 +898,7 @@ function Contacts(wixApi) {
         rest.putJson('https://' + options.host + options.path, upsertData, {
             headers : options.headers
         }).on('complete', function(data, response) {
-            if(response.statusCode === 200) {
+            if(response.statusCode >= 200 && response.statusCode < 300) {
 
                 deferred.resolve(data.contactId);
             } else {


### PR DESCRIPTION
Some API methods return HTTP success codes other than 200. One such example is reconcile contact, which returned HTTP code 201. I fixed the code to accept any response code in the range 200-299.